### PR TITLE
Fix template workbook handling in Excel renderer

### DIFF
--- a/src/main/java/com/example/reporting/core/ExcelRenderer.java
+++ b/src/main/java/com/example/reporting/core/ExcelRenderer.java
@@ -46,12 +46,16 @@ public class ExcelRenderer {
         for (String k : data.keySet()) ctx.putVar(k, data.get(k));
         ctx.putVar("meta", meta);
 
-        PoiTransformer transformer = PoiTransformer.createSxssfTransformer(templateStream, 1000, true);
-        JxlsHelper.getInstance().setUseFastFormulaProcessor(true).processTemplate(ctx, transformer);
-        try (OutputStream os = Files.newOutputStream(out)) {
-            transformer.write(os);
+        try (Workbook templateWorkbook = WorkbookFactory.create(templateStream)) {
+            PoiTransformer transformer = PoiTransformer.createSxssfTransformer(templateWorkbook, 1000, true);
+            JxlsHelper.getInstance().setUseFastFormulaProcessor(true).processTemplate(ctx, transformer);
+            try (OutputStream os = Files.newOutputStream(out)) {
+                transformer.write(os);
+            }
+            return out;
+        } catch (org.apache.poi.openxml4j.exceptions.InvalidFormatException e) {
+            throw new IOException("Invalid Excel template format", e);
         }
-        return out;
     }
 
     private void writeTable(Sheet sh, List<Map<String,Object>> rows) {


### PR DESCRIPTION
## Summary
- create a Workbook from the provided template stream before building the SXSSF transformer
- wrap template loading to throw a helpful IOException when the template format is invalid

## Testing
- mvn -q -DskipTests package *(fails: cannot download spring-boot parent due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68da2ceac0cc83308b319072cdbfb90b