### PR TITLE
Fix Excel renderer output stream handling

### DIFF
--- a/src/main/java/com/example/reporting/core/ExcelRenderer.java
+++ b/src/main/java/com/example/reporting/core/ExcelRenderer.java
@@ -50,7 +50,7 @@ public class ExcelRenderer {
             PoiTransformer transformer = PoiTransformer.createSxssfTransformer(templateWorkbook, 1000, true);
             JxlsHelper.getInstance().setUseFastFormulaProcessor(true).processTemplate(ctx, transformer);
             try (OutputStream os = Files.newOutputStream(out)) {
-                transformer.write(os);
+                transformer.getWorkbook().write(os);
             }
             return out;
         } catch (org.apache.poi.openxml4j.exceptions.InvalidFormatException e) {


### PR DESCRIPTION
## Summary
- replace usage of the deprecated PoiTransformer#write(OutputStream) overload with writing through the workbook to match the current API

## Testing
- mvn -q -DskipTests package *(fails: unable to download parent POM due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68da2e30966883309a0dbd86007f7453