### PR TITLE
Fix H2 schema binary column type for tests

### DIFF
--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -3,5 +3,5 @@ CREATE TABLE IF NOT EXISTS report_config (
     report_code VARCHAR(255) NOT NULL,
     version VARCHAR(255) NOT NULL,
     yaml_config CLOB NOT NULL,
-    template_bytes BLOB
+    template_bytes BYTEA
 );


### PR DESCRIPTION
## Summary
- replace the `template_bytes` column definition in the test schema with BYTEA so it works with H2 in PostgreSQL mode

## Testing
- mvn test *(fails: unable to download dependencies due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68da37a7a19c83309a3d103ac68a4dbb