### PR TITLE
Fix Excel rendering output stream initialization

### DIFF
--- a/src/main/java/com/example/reporting/core/ExcelRenderer.java
+++ b/src/main/java/com/example/reporting/core/ExcelRenderer.java
@@ -46,12 +46,12 @@ public class ExcelRenderer {
         for (String k : data.keySet()) ctx.putVar(k, data.get(k));
         ctx.putVar("meta", meta);
 
-        try (Workbook templateWorkbook = WorkbookFactory.create(templateStream)) {
+        try (Workbook templateWorkbook = WorkbookFactory.create(templateStream);
+             OutputStream os = Files.newOutputStream(out)) {
             PoiTransformer transformer = PoiTransformer.createSxssfTransformer(templateWorkbook, 1000, true);
+            transformer.setOutputStream(os);
             JxlsHelper.getInstance().setUseFastFormulaProcessor(true).processTemplate(ctx, transformer);
-            try (OutputStream os = Files.newOutputStream(out)) {
-                transformer.getWorkbook().write(os);
-            }
+            transformer.write();
             return out;
         }
     }


### PR DESCRIPTION
## Summary
- ensure the SXSSF transformer is given an output stream before template processing
- write the workbook via the transformer to avoid IllegalStateException

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to 403 when downloading Spring Boot parent)*

------
https://chatgpt.com/codex/tasks/task_e_68da391c94448330a34add495cf4e761