### PR TITLE
Fix JDBC dataset map case sensitivity

### DIFF
--- a/src/main/java/com/example/reporting/core/JdbcDatasetReader.java
+++ b/src/main/java/com/example/reporting/core/JdbcDatasetReader.java
@@ -5,10 +5,10 @@ import com.example.reporting.domain.DatasetDef;
 import com.example.reporting.domain.SourceDef;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedCaseInsensitiveMap;
 
 import javax.sql.DataSource;
 import java.util.*;
-import java.util.stream.Stream;
 
 @Component
 public class JdbcDatasetReader implements DatasetReader {
@@ -33,13 +33,13 @@ public class JdbcDatasetReader implements DatasetReader {
         String key = Optional.ofNullable(s.connection()).orElse("default");
         NamedParameterJdbcTemplate tpl = templates.getOrDefault(key, templates.get("default"));
         return tpl.query(s.query(), params, (rs, i) -> {
-            int c = rs.getMetaData().getColumnCount();
-            Map<String,Object> map = new LinkedHashMap<>();
-            for (int k=1; k<=c; k++) {
+            int columnCount = rs.getMetaData().getColumnCount();
+            Map<String,Object> row = new LinkedCaseInsensitiveMap<>(columnCount);
+            for (int k = 1; k <= columnCount; k++) {
                 String name = rs.getMetaData().getColumnLabel(k);
-                map.put(name, rs.getObject(k));
+                row.put(name, rs.getObject(k));
             }
-            return map;
+            return row;
         });
     }
 }


### PR DESCRIPTION
## Summary
- ensure JDBC dataset rows are stored in a case-insensitive map so JXLS expressions such as `${row.id}` resolve correctly

## Testing
- unable to run `mvn test` (dependency download blocked by 403 from Maven Central)


------
https://chatgpt.com/codex/tasks/task_e_68daa2d1ae80833088605d49b09209f0